### PR TITLE
Fix source java location

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ COPY --from=sbt-cache /root/.ivy2 ${JENKINS_HOME}/.ivy2
 COPY --from=sbt-cache /root/.sbt ${JENKINS_HOME}/.sbt
 COPY --from=sbt-plugins-cache /root/.ivy2 ${JENKINS_HOME}/.ivy2
 COPY --from=sbt-plugins-cache /root/.sbt ${JENKINS_HOME}/.sbt
-COPY --from=jdk /usr/lib/jvm/java-8-openjdk-amd64 /usr/lib/jvm/java-8-openjdk-amd64
+COPY --from=jdk /usr/local/openjdk-8/ /usr/lib/jvm/java-8-openjdk-amd64
 
 USER root
 RUN chown -R jenkins ${JENKINS_HOME}


### PR DESCRIPTION
Java appears to have moved from `openjdk-8`.  This updates the location.

Tested locally, able to `sbt compile && sbt test && sbt run` in the fake-project without issue.

Edited output:
```
[info]   Compilation completed in 12.166 s
[success] Total time: 16 s, completed May 13, 2020 6:44:31 PM
[info] Loading project definition from /code/fake-project/project
[info] Set current project to fake-project (in build file:/code/fake-project/)
[info] Executing in batch mode. For better performance use sbt's shell
[success] Total time: 0 s, completed May 13, 2020 6:44:40 PM
[info] Running com.dwolla.fake.Fake
Hello, World!
[success] Total time: 1 s, completed May 13, 2020 6:45:18 PM
```

Nvm is installed as expected as well:
```
$ source .nvm/nvm.sh
$ nvm --version
0.34.0
```

